### PR TITLE
Update 14200_110.txt - Bridge Status Typo Fix

### DIFF
--- a/patch/RSCE_UTF8/14200_110.txt
+++ b/patch/RSCE_UTF8/14200_110.txt
@@ -3,7 +3,7 @@
 [ENDBLOCK]
 Notice
 [ENDBLOCK]
-<TAG_007>The bridge his down.
+<TAG_007>The bridge is down.
 
 [ENDBLOCK]
 Sailor


### PR DESCRIPTION
Whose bridge is down? Now we may never know. 

Seriously, though, I was doing a quick perusal of recent changes and saw this had a tense change (previously 'The bridge has fallen.'), and it seemed to me like a typo slipped in. Now I have no context for where this is used, so if I'm missing an implementation quirk, or some sort of pun, or an intentional localization, please throw this PR straight into the trash, but I thought I'd try to help.